### PR TITLE
Updating sample to use latest preview libs

### DIFF
--- a/Sample.Common/Authentication/AuthenticationProvider.cs
+++ b/Sample.Common/Authentication/AuthenticationProvider.cs
@@ -12,10 +12,9 @@ namespace Sample.Common.Authentication
     using System.Security.Claims;
     using System.Threading;
     using System.Threading.Tasks;
-
-    using Microsoft.Graph.Core;
-    using Microsoft.Graph.Core.Telemetry;
-    using Microsoft.Graph.StatefulClient.Authentication;
+    using Microsoft.Graph.Communications.Client.Authentication;
+    using Microsoft.Graph.Communications.Common;
+    using Microsoft.Graph.Communications.Common.Telemetry;
     using Microsoft.IdentityModel.Clients.ActiveDirectory;
     using Microsoft.IdentityModel.Protocols;
     using Microsoft.IdentityModel.Protocols.OpenIdConnect;

--- a/Sample.Common/Logging/ExceptionLogger.cs
+++ b/Sample.Common/Logging/ExceptionLogger.cs
@@ -10,10 +10,10 @@
 
 namespace Sample.Common.Logging
 {
+    using Microsoft.Graph.Communications.Common.Telemetry;
     using System.Threading;
     using System.Threading.Tasks;
     using System.Web.Http.ExceptionHandling;
-    using Microsoft.Graph.Core.Telemetry;
 
     /// <summary>
     /// The exception logger.

--- a/Sample.Common/Meetings/JoinInfo.cs
+++ b/Sample.Common/Meetings/JoinInfo.cs
@@ -5,6 +5,8 @@
 
 namespace Sample.Common.Meetings
 {
+    extern alias BetaLib;
+    using Beta = BetaLib.Microsoft.Graph;
     using System;
     using System.Collections.Generic;
     using System.IO;
@@ -25,7 +27,7 @@ namespace Sample.Common.Meetings
         /// </summary>
         /// <param name="joinURL">Join URL from Team's meeting body.</param>
         /// <returns>Parsed data.</returns>
-        public static (ChatInfo, MeetingInfo) ParseJoinURL(string joinURL)
+        public static (Beta.ChatInfo, Beta.MeetingInfo) ParseJoinURL(string joinURL)
         {
             var decodedURL = WebUtility.UrlDecode(joinURL);
 
@@ -43,8 +45,8 @@ namespace Sample.Common.Meetings
             {
                 var ctxt = (Context)new DataContractJsonSerializer(typeof(Context)).ReadObject(stream);
                 return (
-                    new ChatInfo { ThreadId = match.Groups["thread"].Value, MessageId = match.Groups["message"].Value, ReplyChainMessageId = ctxt.MessageId },
-                    new OrganizerMeetingInfo { Organizer = new IdentitySet { User = new Identity { Id = ctxt.Oid, AdditionalData = new Dictionary<string, object> { { "TenantId", ctxt.Tid } } } } });
+                    new Beta.ChatInfo { ThreadId = match.Groups["thread"].Value, MessageId = match.Groups["message"].Value, ReplyChainMessageId = ctxt.MessageId },
+                    new Beta.OrganizerMeetingInfo { Organizer = new Beta.IdentitySet { User = new Beta.Identity { Id = ctxt.Oid, AdditionalData = new Dictionary<string, object> { { "TenantId", ctxt.Tid } } } } });
             }
         }
 

--- a/Sample.Common/OnlineMeetingsHelper/OnlineMeetingHelper.cs
+++ b/Sample.Common/OnlineMeetingsHelper/OnlineMeetingHelper.cs
@@ -8,8 +8,7 @@ namespace Sample.Common.OnlineMeetings
     using System;
     using System.Threading.Tasks;
     using Microsoft.Graph;
-    using Microsoft.Graph.CoreSDK;
-    using Microsoft.Graph.StatefulClient.Authentication;
+    using Microsoft.Graph.Communications.Client.Authentication;
 
     /// <summary>
     /// Online meeting class to fetch meeting info based of meeting id (ex: vtckey).
@@ -37,13 +36,13 @@ namespace Sample.Common.OnlineMeetings
         /// <param name="meetingId">The meeting identifier.</param>
         /// <param name="correlationId">The correlation identifier.</param>
         /// <returns> The onlinemeeting. </returns>
-        public async Task<Microsoft.Graph.OnlineMeeting> GetOnlineMeetingAsync(string tenantId, string meetingId, Guid correlationId)
+        public async Task<OnlineMeeting> GetOnlineMeetingAsync(string tenantId, string meetingId, Guid correlationId)
         {
             IAuthenticationProvider GetAuthenticationProvider()
             {
                 return new DelegateAuthenticationProvider(async request =>
                 {
-                    request.Headers.Add(CoreConstants.Headers.ScenarioId, correlationId.ToString());
+                    // request.Headers.Add(CoreConstants.Headers.ScenarioId, correlationId.ToString());
                     request.Headers.Add(CoreConstants.Headers.ClientRequestId, Guid.NewGuid().ToString());
 
                     await this.requestAuthenticationProvider.AuthenticateOutboundRequestAsync(request, tenantId)
@@ -51,9 +50,8 @@ namespace Sample.Common.OnlineMeetings
                 });
             }
 
-            var statelessClient = new DefaultContainerClient(this.graphEndpointUri.AbsoluteUri, GetAuthenticationProvider());
+            var statelessClient = new CallsGraphServiceClient(this.graphEndpointUri.AbsoluteUri, GetAuthenticationProvider());
             var meetingRequest = statelessClient.App.OnlineMeetings[meetingId].Request();
-
             var meeting = await meetingRequest.GetAsync().ConfigureAwait(false);
 
             return meeting;

--- a/Sample.Common/Sample.Common.csproj
+++ b/Sample.Common/Sample.Common.csproj
@@ -9,14 +9,24 @@
 
   
 
-    <ItemGroup>
+  <ItemGroup>
         <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.6" />
-        <PackageReference Include="Microsoft.Graph.CoreSDK" version="1.0.0-prerelease.48" />
-        <PackageReference Include="Microsoft.Graph.StatefulClient" Version="1.0.0-prerelease.48" />
+        <PackageReference Include="Microsoft.Graph.Communications.Core.Calls" version="1.1.0-prerelease.2237" />
+        <PackageReference Include="Microsoft.Graph.Communications.Core" version="1.1.0-prerelease.2237" />
+        <PackageReference Include="Microsoft.Graph.Communications.Client" Version="1.1.0-prerelease.2237" />
         <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.19.8" />
         <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.2.4" />
+        <PackageReference Include="Microsoft.Graph.Beta" Version="0.12.0-preview" />
         <Reference Include="System.Data" />
         <Reference Include="System.Data.Entity" />
         <Reference Include="System.Net.Http" />
     </ItemGroup>
+
+  <Target Name="ChangeAliasesOfStrongNameAssemblies" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">
+    <ItemGroup>
+      <ReferencePath Condition="'%(FileName)' == 'Microsoft.Graph.Beta'">
+        <Aliases>BetaLib</Aliases>
+      </ReferencePath>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/TeamsIVRBotSample/Bot/Bot.cs
+++ b/TeamsIVRBotSample/Bot/Bot.cs
@@ -3,10 +3,11 @@
     using Microsoft.ApplicationInsights;
     using Microsoft.Extensions.Logging;
     using Microsoft.Graph;
-    using Microsoft.Graph.Calls;
+    using Microsoft.Graph.Communications.Calls;
+    using Microsoft.Graph.Communications.Client;
+    using Microsoft.Graph.Communications.Common.Telemetry;
+    using Microsoft.Graph.Communications.Resources;
     using Microsoft.Graph.Core;
-    using Microsoft.Graph.Core.Telemetry;
-    using Microsoft.Graph.StatefulClient;
     using Sample.Common.Authentication;
     using Sample.Common.Meetings;
     using Sample.Common.OnlineMeetings;
@@ -53,13 +54,12 @@
                 options.AppSecret,
                 this.graphLogger);
 
-            var builder = new StatefulClientBuilder("TeamsIVRBotSample", options.AppId, this.graphLogger);
+            var builder = new CommunicationsClientBuilder("TeamsIVRBotSample", options.AppId, this.graphLogger);
             builder.SetAuthenticationProvider(authProvider);
             builder.SetNotificationUrl(instanceNotificationUri);
             builder.SetServiceBaseUrl(options.PlaceCallEndpointUrl);
 
             this.Client = builder.Build();
-
 
             this.Client.Calls().OnIncoming += this.CallsOnIncoming;
             this.Client.Calls().OnUpdated += this.CallsOnUpdated;
@@ -73,7 +73,7 @@
         /// <value>
         /// The client.
         /// </value>
-        public IStatefulClient Client { get; }
+        public ICommunicationsClient Client { get; }
 
 
 

--- a/TeamsIVRBotSample/Bot/CallAffinityMiddleware.cs
+++ b/TeamsIVRBotSample/Bot/CallAffinityMiddleware.cs
@@ -10,7 +10,7 @@
     using Microsoft.AspNetCore.Http.Extensions;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.WebApiCompatShim;
-    using Microsoft.Graph.Core.Telemetry;
+    using Microsoft.Graph.Communications.Common.Telemetry;
 
     /// <summary>
     /// The call affinity helper class to help re-route calls to specific web instance.

--- a/TeamsIVRBotSample/Bot/CallHandler.cs
+++ b/TeamsIVRBotSample/Bot/CallHandler.cs
@@ -1,13 +1,14 @@
 ﻿namespace ThoughtStuff.TeamsSamples.IVRBotSample
 {
+    extern alias BetaLib;
+    using Beta = BetaLib.Microsoft.Graph;
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Microsoft.Graph;
-    using Microsoft.Graph.Calls;
-    using Microsoft.Graph.Core.Telemetry;
-    using Microsoft.Graph.CoreSDK.Serialization;
-    using Microsoft.Graph.StatefulClient;
+    using Microsoft.Graph.Communications.Calls;
+    using Microsoft.Graph.Communications.Common.Telemetry;
+    using Microsoft.Graph.Communications.Resources;
 
     /// <summary>
     /// Base class for call handler for event handling, logging and cleanup.
@@ -60,7 +61,7 @@
         /// <summary>
         /// Gets the serializer
         /// </summary>
-        private static Serializer Serializer { get; } = new Serializer(pretty: true);
+        private static Serializer Serializer { get; } = new Serializer();
 
         /// <inheritdoc />
         public void Dispose()
@@ -89,7 +90,7 @@
         /// </summary>
         /// <param name="sender">The sender</param>
         /// <param name="args">The arguments</param>
-        protected virtual void ParticipantsOnUpdated(ICallParticipantCollection sender, CollectionEventArgs<ICallParticipant> args)
+        protected virtual void ParticipantsOnUpdated(IParticipantCollection sender, CollectionEventArgs<IParticipant> args)
         {
             // do nothing in base class.
         }
@@ -99,7 +100,7 @@
         /// </summary>
         /// <param name="sender">The sender</param>
         /// <param name="args">The arguments</param>
-        protected virtual void ParticipantOnUpdated(ICallParticipant sender, ResourceEventArgs<Participant> args)
+        protected virtual void ParticipantOnUpdated(IParticipant sender, ResourceEventArgs<Participant> args)
         {
             // do nothing in base class.
         }
@@ -122,7 +123,7 @@
         /// </summary>
         /// <param name="sender">The sender</param>
         /// <param name="args">The arguments</param>
-        private void OnParticipantUpdated(ICallParticipant sender, ResourceEventArgs<Participant> args)
+        private void OnParticipantUpdated(IParticipant sender, ResourceEventArgs<Participant> args)
         {
             var outcome = Serializer.SerializeObject(sender.Resource);
             this.OutcomesLogMostRecentFirst.AddFirst("Participant Updated:\n" + outcome);
@@ -135,7 +136,7 @@
         /// </summary>
         /// <param name="sender">The sender</param>
         /// <param name="args">The arguments</param>
-        private void OnParticipantsUpdated(ICallParticipantCollection sender, CollectionEventArgs<ICallParticipant> args)
+        private void OnParticipantsUpdated(IParticipantCollection sender, CollectionEventArgs<IParticipant> args)
         {
             foreach (var participant in args.AddedResources)
             {

--- a/TeamsIVRBotSample/Bot/IncomingCallHandler.cs
+++ b/TeamsIVRBotSample/Bot/IncomingCallHandler.cs
@@ -1,10 +1,8 @@
 ﻿namespace ThoughtStuff.TeamsSamples.IVRBotSample
 {
     using Microsoft.Graph;
-    using Microsoft.Graph.Calls;
-    using Microsoft.Graph.Core.Telemetry;
-    using Microsoft.Graph.Core.Transport;
-    using Microsoft.Graph.StatefulClient;
+    using Microsoft.Graph.Communications.Calls;
+    using Microsoft.Graph.Communications.Resources;
     using Newtonsoft.Json.Linq;
     using System;
     using System.Collections.Generic;
@@ -126,11 +124,11 @@
                 await this.Call.PlayPromptAsync(new List<MediaPrompt> { ttsMediaPrompt }).ConfigureAwait(false);
 
 
-                this.Logger.Info("Started playing prompt:" + filename);
+                this.Logger.Log(System.Diagnostics.TraceLevel.Info, "Started playing prompt:" + filename);
             }
             catch (Exception ex)
             {
-                this.Logger.Error(ex, $"Failed to play notification prompt: " + filename);
+                this.Logger.Log(System.Diagnostics.TraceLevel.Info, $"Failed to play notification prompt: " + filename);
                 throw;
             }
 

--- a/TeamsIVRBotSample/Bot/IncomingCallHandler.cs
+++ b/TeamsIVRBotSample/Bot/IncomingCallHandler.cs
@@ -6,6 +6,7 @@
     using Newtonsoft.Json.Linq;
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.IO;
     using System.Net;
     using System.Text;
@@ -124,11 +125,11 @@
                 await this.Call.PlayPromptAsync(new List<MediaPrompt> { ttsMediaPrompt }).ConfigureAwait(false);
 
 
-                this.Logger.Log(System.Diagnostics.TraceLevel.Info, "Started playing prompt:" + filename);
+                this.Logger.Log(TraceLevel.Info, "Started playing prompt:" + filename);
             }
             catch (Exception ex)
             {
-                this.Logger.Log(System.Diagnostics.TraceLevel.Info, $"Failed to play notification prompt: " + filename);
+                this.Logger.Log(TraceLevel.Info, $"Failed to play notification prompt: " + filename);
                 throw;
             }
 

--- a/TeamsIVRBotSample/Controllers/PlatformCallController.cs
+++ b/TeamsIVRBotSample/Controllers/PlatformCallController.cs
@@ -3,12 +3,14 @@
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.WebApiCompatShim;
     using Microsoft.Graph;
-    using Microsoft.Graph.Core.Telemetry;
+    using Microsoft.Graph.Communications.Calls;
+    using Microsoft.Graph.Communications.Client;
+    using Microsoft.Graph.Communications.Common.Telemetry;
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading.Tasks;
     using ThoughtStuff.TeamsSamples.IVRBotSample;
-
+    using CommunicationsClientExtensions = Microsoft.Graph.Communications.Client.CommunicationsClientExtensions;
     /// <summary>
     /// Entry point for handling call-related web hook requests from the stateful client
     /// </summary>
@@ -42,8 +44,8 @@
 
             this.bot.AddCallbackLog($"Process incoming request {requestUri}");
 
-            // Pass the incoming message to the Calling SDK, via the bot class.
-            var response = await this.bot.Client.ProcessNotificationAsync(requestMessage).ConfigureAwait(false);
+            // Pass the incoming message to the Calling SDK, via the bot class
+            var response = await CommunicationsClientExtensions.ProcessNotificationAsync(this.bot.Client, requestMessage).ConfigureAwait(false);
 
             // Convert the status code, content of HttpResponseMessage to IActionResult,
             // and copy the headers from response to HttpContext.Response.Headers.

--- a/TeamsIVRBotSample/Extensions/ControllerExtensions.cs
+++ b/TeamsIVRBotSample/Extensions/ControllerExtensions.cs
@@ -1,7 +1,6 @@
 ﻿namespace Microsoft.AspNetCore.Mvc
 {
     using Microsoft.Extensions.Primitives;
-    using Microsoft.Graph.CoreSDK.Exceptions;
     using System;
     using System.Linq;
     using System.Net;

--- a/TeamsIVRBotSample/Startup.cs
+++ b/TeamsIVRBotSample/Startup.cs
@@ -11,7 +11,7 @@ namespace ThoughtStuff.TeamsSamples
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
-    using Microsoft.Graph.Core.Telemetry;
+    using Microsoft.Graph.Communications.Common.Telemetry;
     using ThoughtStuff.TeamsSamples.IVRBotSample;
 
     /// <summary>

--- a/TeamsIVRBotSample/TeamsIVRBotSample.csproj
+++ b/TeamsIVRBotSample/TeamsIVRBotSample.csproj
@@ -49,8 +49,11 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.0.2" />
-    <PackageReference Include="Microsoft.Graph.Calls" Version="1.0.0-prerelease.48" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
+    <PackageReference Include="Microsoft.Graph.Communications.Common" Version="1.1.0-prerelease.2237" />
+    <PackageReference Include="Microsoft.Graph.Communications.Calls" Version="1.1.0-prerelease.2237" />
+    <PackageReference Include="Microsoft.Graph.Communications.Core" Version="1.1.0-prerelease.2237" />
+    <PackageReference Include="Microsoft.Graph.Communications.Client" Version="1.1.0-prerelease.2237" />
   </ItemGroup>
   
   <ItemGroup>
@@ -80,5 +83,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-
+  <Target Name="ChangeAliasesOfStrongNameAssemblies" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">
+    <ItemGroup>
+      <ReferencePath Condition="'%(FileName)' == 'Microsoft.Graph.Beta'">
+        <Aliases>BetaLib</Aliases>
+      </ReferencePath>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/TeamsIVRBotSample/appsettings.json
+++ b/TeamsIVRBotSample/appsettings.json
@@ -10,7 +10,7 @@
   "Bot": {
     "AppId": "",
     "AppSecret": "",
-    "PlaceCallEndpointUrl": "https://graph.microsoft.com/testcomms",
+    "PlaceCallEndpointUrl": "https://graph.microsoft.com/beta",
     "AuthTokenAudience": "https://graph.microsoft.com",
     "BotBaseUrl": ""
   }


### PR DESCRIPTION
I was attempting to add recording but the comms nuget packages have changed significantly. I felt for new people looking at this sample code it might be good to upgrade the existing nuget packages in case they want to try to build off of it. 


I upgraded as easily as I could but there were certain things that seem less clear. 
- The largest concern would have to be the scenario id header which does not seem to be defined anymore
- All of the "graph" objects seemed to be in the beta version of graph so I had to define the beta graph lib under an alias and use "beta" everywhere.

I just tested running the normal voice call game example and it seemed to work in my scenario where I was using ngrok. I understand if the sample works exactly how you want it to to and you would prefer to not take this pull request.